### PR TITLE
feat(site): replace nav create link with +Create dropdown

### DIFF
--- a/site/src/components/NavBar.astro
+++ b/site/src/components/NavBar.astro
@@ -18,10 +18,37 @@ const { lang } = Astro.props;
       <a href="/" class="text-light-gray hover:text-white transition-colors text-sm">{t(lang, 'nav.hackathons')}</a>
       <a href="/proposals" class="text-muted hover:text-white transition-colors text-sm">{t(lang, 'nav.proposals')}</a>
       <a href="/guides/hacker" class="text-muted hover:text-white transition-colors text-sm">{t(lang, 'nav.guides')}</a>
-      <a href="/create-hackathon" class="text-muted hover:text-white transition-colors text-sm">{t(lang, 'nav.create_hackathon')}</a>
     </div>
 
     <div class="flex items-center gap-4">
+      <div class="relative" id="create-dropdown-wrap">
+        <button
+          type="button"
+          id="create-dropdown-trigger"
+          class="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-lime-primary text-near-black text-sm font-medium hover:bg-lime-primary/90 transition-colors"
+          aria-haspopup="true"
+          aria-expanded="false"
+          aria-label={t(lang, 'nav.create_btn')}
+        >
+          <span>{t(lang, 'nav.create_btn')}</span>
+          <svg id="create-dropdown-chevron" class="w-4 h-4 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+        <div
+          id="create-dropdown-panel"
+          class="absolute right-0 top-full mt-1.5 min-w-[10rem] py-1 bg-dark-bg border border-secondary-bg rounded-lg shadow-lg z-50 hidden"
+          role="menu"
+        >
+          <a href="/create-hackathon" class="block px-4 py-2.5 text-sm text-white hover:bg-secondary-bg hover:text-lime-primary transition-colors first:rounded-t-lg" role="menuitem">
+            {t(lang, 'nav.create_hackathon')}
+          </a>
+          <a href="/create-proposal" class="block px-4 py-2.5 text-sm text-white hover:bg-secondary-bg hover:text-lime-primary transition-colors last:rounded-b-lg" role="menuitem">
+            {t(lang, 'nav.create_proposal')}
+          </a>
+        </div>
+      </div>
+
       <button id="lang-switch" type="button" class="cursor-pointer py-2 px-1 text-muted hover:text-white text-sm transition-colors relative z-10" aria-label="Switch language">
         {t(lang, 'nav.lang_switch')}
       </button>
@@ -30,3 +57,33 @@ const { lang } = Astro.props;
     </div>
   </div>
 </nav>
+
+<script>
+  (function () {
+    const wrap = document.getElementById('create-dropdown-wrap');
+    const trigger = document.getElementById('create-dropdown-trigger');
+    const panel = document.getElementById('create-dropdown-panel');
+    const chevron = document.getElementById('create-dropdown-chevron');
+    if (!wrap || !trigger || !panel) return;
+
+    function open() {
+      panel.classList.remove('hidden');
+      trigger.setAttribute('aria-expanded', 'true');
+      chevron?.classList.add('rotate-180');
+    }
+    function close() {
+      panel.classList.add('hidden');
+      trigger.setAttribute('aria-expanded', 'false');
+      chevron?.classList.remove('rotate-180');
+    }
+
+    trigger.addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (panel.classList.contains('hidden')) open();
+      else close();
+    });
+
+    document.addEventListener('click', () => close());
+    wrap.addEventListener('click', (e) => e.stopPropagation());
+  })();
+</script>

--- a/site/src/i18n/en.yml
+++ b/site/src/i18n/en.yml
@@ -6,7 +6,9 @@ nav:
   hackers: "Hackers"
   guides: "Guides"
   proposals: "Proposals"
+  create_btn: "+ Create"
   create_hackathon: "Create Hackathon"
+  create_proposal: "Create Proposal"
   lang_switch: "中 / EN"
 footer:
   platform: "Platform"

--- a/site/src/i18n/zh.yml
+++ b/site/src/i18n/zh.yml
@@ -6,7 +6,9 @@ nav:
   hackers: "参赛者"
   guides: "指南"
   proposals: "提案"
+  create_btn: "+ 创建"
   create_hackathon: "创建活动"
+  create_proposal: "创建提案"
   lang_switch: "EN / 中"
 footer:
   platform: "平台"


### PR DESCRIPTION
## Summary
- Replace the single "创建活动" text link in NavBar with a **lime-green "+创建" dropdown button**
- Dropdown offers two options: **Create Hackathon** (`/create-hackathon`) and **Create Proposal** (`/create-proposal`)
- Add missing i18n keys: `nav.create_btn`, `nav.create_proposal` (en + zh)
- Fix bugs from the original stash: corrupted script tail, missing chevron element id

## Changes
- `site/src/components/NavBar.astro` — dropdown button + vanilla JS toggle script
- `site/src/i18n/en.yml` — add `create_btn` and `create_proposal` keys
- `site/src/i18n/zh.yml` — add `create_btn` and `create_proposal` keys

## Test plan
- [ ] Verify dropdown opens/closes on click
- [ ] Verify clicking outside closes the dropdown
- [ ] Verify chevron rotates on open
- [ ] Verify both menu items navigate to correct pages
- [ ] Verify i18n works in both en and zh

🤖 Generated with [Claude Code](https://claude.com/claude-code)