### PR TITLE
fix(site): use standalone render() from astro:content for MDX

### DIFF
--- a/site/src/pages/projects/[hackathon]/[team].astro
+++ b/site/src/pages/projects/[hackathon]/[team].astro
@@ -1,7 +1,7 @@
 ---
 export const prerender = false;
 import BaseLayout from '../../../layouts/BaseLayout.astro';
-import { getCollection } from 'astro:content';
+import { getCollection, render } from 'astro:content';
 import { t, localize, getLangFromUrl } from '../../../lib/i18n';
 import type { Lang } from '../../../lib/i18n';
 const { hackathon, team } = Astro.params;
@@ -19,7 +19,7 @@ const allReadmes = await getCollection('readmes');
 const readmeEntry = allReadmes.find(r => r.id.startsWith(`${hackathon}/submissions/${team}/`));
 let ReadmeContent: any = null;
 if (readmeEntry) {
-  const rendered = await readmeEntry.render();
+  const rendered = await render(readmeEntry);
   ReadmeContent = rendered.Content;
 }
 


### PR DESCRIPTION
## Summary
- Fix `readmeEntry.render is not a function` error on project detail pages (e.g. `/projects/dishuihu-ai-opc-global-challenge-2026/team-ai-voyager`)
- Astro 5 changed `render()` from an entry method to a standalone function imported from `astro:content`
- Changed `entry.render()` → `render(entry)`

## Root Cause
PR #20 introduced the `readmes` content collection but used the Astro 4 API (`entry.render()`). Astro 5 requires `import { render } from 'astro:content'` and calling `render(entry)`.

## Test Plan
- [x] `pnpm run build` succeeds
- [x] `/projects/dishuihu-ai-opc-global-challenge-2026/team-ai-voyager` returns 200 locally
- [ ] Verify README.mdx renders as formatted HTML (headings, bold, lists) on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)