### PR TITLE
docs: archive preview deploy OAuth design docs

### DIFF
--- a/docs/plans/2026-03-04-preview-deploy-oauth-design.md
+++ b/docs/plans/2026-03-04-preview-deploy-oauth-design.md
@@ -1,0 +1,178 @@
+# Preview Deployment & OAuth Design
+
+**Date:** 2026-03-04
+**Status:** Approved
+
+## Problem
+
+The current Cloudflare Pages build configuration uses `cd site && pnpm run deploy` (wrangler deploy) for both the "Deploy command" and "Version command". This deploys to a single Cloudflare Worker named "synnovator" regardless of branch, meaning PR preview deployments overwrite production. There is no isolated preview environment, and GitHub OAuth callbacks are hardcoded to the production domain.
+
+## Decision
+
+**Approach A: Two GitHub OAuth Apps + Native Cloudflare Pages Deployment**
+
+Switch from `wrangler deploy` to native Cloudflare Pages build (`astro build`), use per-environment variables for production vs preview, and create a second GitHub OAuth App for preview deployments with cross-subdomain cookie sharing.
+
+## Architecture
+
+### Deployment Flow
+
+```
+Git Push to main  → Pages build (astro build) → Production at home.synnovator.space
+Git Push to PR    → Pages build (astro build) → Preview at <hash>.synnovator.pages.dev
+```
+
+### OAuth Flow (Preview)
+
+```
+Developer on abc123.synnovator.pages.dev
+  → clicks Login
+  → login.ts reads SITE_URL=https://synnovator.pages.dev
+  → redirects to GitHub with redirect_uri=synnovator.pages.dev/api/auth/callback
+  → GitHub redirects to synnovator.pages.dev/api/auth/callback
+  → callback sets cookie with Domain=synnovator.pages.dev
+  → redirects to abc123.synnovator.pages.dev (from state parameter)
+  → preview subdomain receives the cookie — session works
+```
+
+Key insight: `pages.dev` is on the public suffix list, so `synnovator.pages.dev` is a registrable domain. Cookies set with `Domain=synnovator.pages.dev` are sent to all `*.synnovator.pages.dev` subdomains.
+
+## Infrastructure Changes
+
+### Cloudflare Pages Dashboard
+
+| Setting | Current | New |
+|---------|---------|-----|
+| Build command | `cd site && pnpm run deploy` | `cd site && pnpm run build` |
+| Build output directory | N/A (Worker deploy) | `site/dist` |
+| Root directory | `/` | `/` |
+| Production branch | `main` | `main` |
+
+### Environment Variables (Pages Dashboard)
+
+| Variable | Production | Preview |
+|----------|-----------|---------|
+| `SITE_URL` | `https://home.synnovator.space` | `https://synnovator.pages.dev` |
+| `GITHUB_CLIENT_ID` | `Iv23liQaa34mwXMU912V` | `<preview-app-id>` |
+| `GITHUB_CLIENT_SECRET` | `<prod-secret>` | `<preview-secret>` |
+| `AUTH_SECRET` | `<shared>` | `<shared>` |
+| `GITHUB_OWNER` | `Synnovator` | `Synnovator` |
+| `GITHUB_REPO` | `monorepo` | `monorepo` |
+| `R2_*` credentials | Same for both | Same for both |
+
+### GitHub OAuth Apps
+
+| App | Callback URL | Usage |
+|-----|-------------|-------|
+| Synnovator (existing) | `https://home.synnovator.space/api/auth/callback` | Production |
+| Synnovator Preview (new) | `https://synnovator.pages.dev/api/auth/callback` | PR previews |
+
+## Code Changes
+
+### 1. `site/src/lib/auth.ts` — Cross-subdomain cookie
+
+Add `cookieDomain` parameter to `setSessionCookie` and `clearSessionCookie`:
+
+```typescript
+export function setSessionCookie(headers: Headers, token: string, cookieDomain?: string): void {
+  let cookie = `${COOKIE_NAME}=${token}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${COOKIE_MAX_AGE}`;
+  if (cookieDomain) {
+    cookie += `; Domain=${cookieDomain}`;
+  }
+  headers.append('Set-Cookie', cookie);
+}
+
+export function clearSessionCookie(headers: Headers, cookieDomain?: string): void {
+  let cookie = `${COOKIE_NAME}=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0`;
+  if (cookieDomain) {
+    cookie += `; Domain=${cookieDomain}`;
+  }
+  headers.append('Set-Cookie', cookie);
+}
+```
+
+### 2. `site/src/pages/api/auth/login.ts` — Full URL in OAuth state
+
+When the request origin differs from `SITE_URL`, include the full origin in `returnTo` so the callback can redirect back to the preview subdomain:
+
+```typescript
+const requestOrigin = new URL(request.url).origin;
+const siteOrigin = new URL(siteUrl).origin;
+
+let returnTo = new URL(request.url).searchParams.get('returnTo')
+  || request.headers.get('Referer')
+  || '/';
+
+// If on a preview subdomain, preserve full URL for cross-origin redirect
+if (requestOrigin !== siteOrigin && !returnTo.startsWith('http')) {
+  returnTo = `${requestOrigin}${returnTo}`;
+}
+```
+
+### 3. `site/src/pages/api/auth/callback.ts` — Redirect validation + domain-aware cookie
+
+```typescript
+// Validate returnTo against allowed origins (prevent open redirect)
+const ALLOWED_PATTERNS = [
+  /^https:\/\/home\.synnovator\.space(\/|$)/,
+  /^https:\/\/([a-z0-9-]+\.)?synnovator\.pages\.dev(\/|$)/,
+  /^\//,  // relative paths
+];
+
+function isAllowedRedirect(url: string): boolean {
+  return ALLOWED_PATTERNS.some(p => p.test(url));
+}
+
+// Derive cookie domain for cross-subdomain sharing on *.pages.dev
+function getCookieDomain(requestUrl: string): string | undefined {
+  const host = new URL(requestUrl).hostname;
+  if (host.endsWith('.pages.dev')) {
+    // e.g., synnovator.pages.dev from synnovator.pages.dev
+    return host.split('.').slice(-3).join('.');
+  }
+  return undefined;
+}
+```
+
+### 4. `site/src/pages/api/auth/logout.ts` — Domain-aware cookie clearing
+
+Pass `cookieDomain` to `clearSessionCookie` using the same `getCookieDomain` logic.
+
+### 5. `site/wrangler.toml` — Local dev defaults
+
+Update `[vars]` to serve as local development defaults only:
+
+```toml
+[vars]
+SITE_URL = "http://localhost:4321"
+GITHUB_CLIENT_ID = "Iv23liQaa34mwXMU912V"
+GITHUB_OWNER = "Synnovator"
+GITHUB_REPO = "monorepo"
+```
+
+Production and preview values are set via the Cloudflare Pages dashboard.
+
+### 6. No changes needed
+
+- `package.json` — keep `deploy` script for manual use
+- `astro.config.mjs` — keep `site` hardcoded (only affects SEO/canonical URLs)
+- `auth.ts` encrypt/decrypt — no changes
+- `me.ts` — no changes (reads cookie normally)
+
+## Manual Setup Steps (Not Code)
+
+1. **Create "Synnovator Preview" GitHub OAuth App** at github.com/organizations/Synnovator/settings/applications
+   - Application name: `Synnovator Preview`
+   - Homepage URL: `https://synnovator.pages.dev`
+   - Authorization callback URL: `https://synnovator.pages.dev/api/auth/callback`
+2. **Update Cloudflare Pages dashboard**:
+   - Change build command to `cd site && pnpm run build`
+   - Set per-environment variables (see table above)
+3. **Generate client secret** for the preview OAuth App and add to Pages preview env vars
+
+## Testing
+
+- Push a PR branch → verify preview URL is generated at `*.synnovator.pages.dev`
+- On preview URL, click Login → verify OAuth flow redirects through `synnovator.pages.dev` and back to preview
+- Verify session cookie works across preview subdomains
+- Verify production deployment at `home.synnovator.space` is unaffected

--- a/docs/plans/2026-03-04-preview-deploy-oauth-implementation.md
+++ b/docs/plans/2026-03-04-preview-deploy-oauth-implementation.md
@@ -1,0 +1,389 @@
+# Preview Deployment & OAuth Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Enable isolated Cloudflare Pages preview deployments for PRs with working GitHub OAuth via a second OAuth App and cross-subdomain cookies.
+
+**Architecture:** Switch from `wrangler deploy` to native Pages build (`astro build`). Use per-environment variables in Pages dashboard for production vs preview. Add domain-aware cookie logic so OAuth sessions work across `*.synnovator.pages.dev` subdomains.
+
+**Tech Stack:** Astro 5, Cloudflare Pages, GitHub OAuth, AES-GCM session cookies
+
+**Design doc:** `docs/plans/2026-03-04-preview-deploy-oauth-design.md`
+
+---
+
+### Task 1: Add `getCookieDomain` helper and update cookie functions in `auth.ts`
+
+**Files:**
+- Modify: `site/src/lib/auth.ts:70-82`
+
+**Step 1: Add `getCookieDomain` utility function**
+
+Add after the `COOKIE_MAX_AGE` constant (line 13), before `deriveKey`:
+
+```typescript
+/**
+ * Derive cookie Domain attribute for cross-subdomain sharing.
+ * On *.pages.dev, returns the registrable domain (e.g. synnovator.pages.dev)
+ * so cookies are shared across preview subdomains.
+ * Returns undefined for custom domains (cookie scoped to exact host).
+ */
+export function getCookieDomain(hostname: string): string | undefined {
+  if (hostname.endsWith('.pages.dev')) {
+    const parts = hostname.split('.');
+    // e.g. "abc123.synnovator.pages.dev" → "synnovator.pages.dev"
+    // e.g. "synnovator.pages.dev" → "synnovator.pages.dev"
+    return parts.slice(-3).join('.');
+  }
+  return undefined;
+}
+```
+
+**Step 2: Update `setSessionCookie` to accept optional domain**
+
+Replace lines 70-75:
+
+```typescript
+export function setSessionCookie(headers: Headers, token: string, cookieDomain?: string): void {
+  let cookie = `${COOKIE_NAME}=${token}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${COOKIE_MAX_AGE}`;
+  if (cookieDomain) {
+    cookie += `; Domain=${cookieDomain}`;
+  }
+  headers.append('Set-Cookie', cookie);
+}
+```
+
+**Step 3: Update `clearSessionCookie` to accept optional domain**
+
+Replace lines 77-82:
+
+```typescript
+export function clearSessionCookie(headers: Headers, cookieDomain?: string): void {
+  let cookie = `${COOKIE_NAME}=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0`;
+  if (cookieDomain) {
+    cookie += `; Domain=${cookieDomain}`;
+  }
+  headers.append('Set-Cookie', cookie);
+}
+```
+
+**Step 4: Verify build**
+
+Run: `cd site && pnpm run build`
+Expected: Build succeeds (no type errors)
+
+**Step 5: Commit**
+
+```bash
+git add site/src/lib/auth.ts
+git commit -m "feat(site): add cross-subdomain cookie support for preview deploys"
+```
+
+---
+
+### Task 2: Add redirect validation helper to `auth.ts`
+
+**Files:**
+- Modify: `site/src/lib/auth.ts` (add at end of file)
+
+**Step 1: Add `isAllowedRedirect` function**
+
+Append to `auth.ts`:
+
+```typescript
+/**
+ * Validate redirect URLs to prevent open redirect attacks.
+ * Allows: relative paths, home.synnovator.space, *.synnovator.pages.dev
+ */
+const ALLOWED_REDIRECT_PATTERNS = [
+  /^\/(?!\/)/,  // relative paths (but not protocol-relative //evil.com)
+  /^https:\/\/home\.synnovator\.space(\/|$)/,
+  /^https:\/\/([a-z0-9-]+\.)?synnovator\.pages\.dev(\/|$)/,
+];
+
+export function isAllowedRedirect(url: string): boolean {
+  return ALLOWED_REDIRECT_PATTERNS.some((p) => p.test(url));
+}
+```
+
+**Step 2: Verify build**
+
+Run: `cd site && pnpm run build`
+Expected: Build succeeds
+
+**Step 3: Commit**
+
+```bash
+git add site/src/lib/auth.ts
+git commit -m "feat(site): add redirect URL validation for OAuth flow"
+```
+
+---
+
+### Task 3: Update `login.ts` — full URL in OAuth state for preview subdomains
+
+**Files:**
+- Modify: `site/src/pages/api/auth/login.ts:5-25`
+
+**Step 1: Rewrite the GET handler**
+
+Replace the entire handler body (lines 5-25):
+
+```typescript
+export const GET: APIRoute = async ({ request, locals }) => {
+  const { env } = locals.runtime;
+  const clientId = env.GITHUB_CLIENT_ID;
+  const siteUrl = env.SITE_URL || 'https://synnovator.pages.dev';
+
+  const requestUrl = new URL(request.url);
+  const requestOrigin = requestUrl.origin;
+  const siteOrigin = new URL(siteUrl).origin;
+
+  let returnTo = requestUrl.searchParams.get('returnTo')
+    || request.headers.get('Referer')
+    || '/';
+
+  // On preview subdomains, preserve full URL so callback can redirect back
+  if (requestOrigin !== siteOrigin && !returnTo.startsWith('http')) {
+    returnTo = `${requestOrigin}${returnTo}`;
+  }
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: `${siteUrl}/api/auth/callback`,
+    scope: 'read:user',
+    state: returnTo,
+  });
+
+  return new Response(null, {
+    status: 302,
+    headers: { Location: `https://github.com/login/oauth/authorize?${params}` },
+  });
+};
+```
+
+**Step 2: Verify build**
+
+Run: `cd site && pnpm run build`
+Expected: Build succeeds
+
+**Step 3: Commit**
+
+```bash
+git add site/src/pages/api/auth/login.ts
+git commit -m "feat(site): preserve preview origin in OAuth state for cross-subdomain redirect"
+```
+
+---
+
+### Task 4: Update `callback.ts` — domain-aware cookie + redirect validation
+
+**Files:**
+- Modify: `site/src/pages/api/auth/callback.ts:1-59`
+
+**Step 1: Rewrite callback with redirect validation and domain-aware cookie**
+
+Replace the entire file:
+
+```typescript
+import type { APIRoute } from 'astro';
+import { encrypt, setSessionCookie, getCookieDomain, isAllowedRedirect } from '../../../lib/auth';
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ request, locals }) => {
+  const { env } = locals.runtime;
+  const url = new URL(request.url);
+  const code = url.searchParams.get('code');
+  const rawReturnTo = url.searchParams.get('state') || '/';
+
+  // Validate redirect target to prevent open redirect
+  const returnTo = isAllowedRedirect(rawReturnTo) ? rawReturnTo : '/';
+
+  if (!code) {
+    return new Response('Missing code parameter', { status: 400 });
+  }
+
+  const tokenRes = await fetch('https://github.com/login/oauth/access_token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({
+      client_id: env.GITHUB_CLIENT_ID,
+      client_secret: env.GITHUB_CLIENT_SECRET,
+      code,
+    }),
+  });
+
+  const tokenData = (await tokenRes.json()) as { access_token?: string; error?: string };
+  if (!tokenData.access_token) {
+    const siteUrl = env.SITE_URL || 'https://synnovator.pages.dev';
+    const loginUrl = `${siteUrl}/api/auth/login?returnTo=${encodeURIComponent(returnTo)}`;
+    return new Response(null, { status: 302, headers: { Location: loginUrl } });
+  }
+
+  const userRes = await fetch('https://api.github.com/user', {
+    headers: {
+      Authorization: `Bearer ${tokenData.access_token}`,
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'Synnovator',
+    },
+  });
+
+  const user = (await userRes.json()) as { login: string; avatar_url: string };
+
+  const token = await encrypt(
+    {
+      login: user.login,
+      avatar_url: user.avatar_url,
+      access_token: tokenData.access_token,
+    },
+    env.AUTH_SECRET,
+  );
+
+  const cookieDomain = getCookieDomain(url.hostname);
+  const headers = new Headers({ Location: returnTo });
+  setSessionCookie(headers, token, cookieDomain);
+  return new Response(null, { status: 302, headers });
+};
+```
+
+**Step 2: Verify build**
+
+Run: `cd site && pnpm run build`
+Expected: Build succeeds
+
+**Step 3: Commit**
+
+```bash
+git add site/src/pages/api/auth/callback.ts
+git commit -m "feat(site): add redirect validation and cross-subdomain cookie to OAuth callback"
+```
+
+---
+
+### Task 5: Update `logout.ts` — domain-aware cookie clearing
+
+**Files:**
+- Modify: `site/src/pages/api/auth/logout.ts:1-11`
+
+**Step 1: Rewrite logout with domain-aware cookie clearing**
+
+Replace the entire file:
+
+```typescript
+import type { APIRoute } from 'astro';
+import { clearSessionCookie, getCookieDomain } from '../../../lib/auth';
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ request }) => {
+  const cookieDomain = getCookieDomain(new URL(request.url).hostname);
+  const headers = new Headers({ Location: '/' });
+  clearSessionCookie(headers, cookieDomain);
+  return new Response(null, { status: 302, headers });
+};
+```
+
+**Step 2: Verify build**
+
+Run: `cd site && pnpm run build`
+Expected: Build succeeds
+
+**Step 3: Commit**
+
+```bash
+git add site/src/pages/api/auth/logout.ts
+git commit -m "feat(site): add cross-subdomain cookie clearing to logout"
+```
+
+---
+
+### Task 6: Update `wrangler.toml` — local dev defaults
+
+**Files:**
+- Modify: `site/wrangler.toml:10-14`
+
+**Step 1: Update `[vars]` section for local development**
+
+Replace lines 10-14:
+
+```toml
+[vars]
+SITE_URL = "http://localhost:4321"
+GITHUB_CLIENT_ID = "Iv23liQaa34mwXMU912V"
+GITHUB_OWNER = "Synnovator"
+GITHUB_REPO = "monorepo"
+```
+
+Note: Production and preview values are set via the Cloudflare Pages dashboard (per-environment), not in this file. This file is only used for local `pnpm run dev`.
+
+**Step 2: Verify build**
+
+Run: `cd site && pnpm run build`
+Expected: Build succeeds
+
+**Step 3: Commit**
+
+```bash
+git add site/wrangler.toml
+git commit -m "chore(site): update wrangler.toml vars to local dev defaults"
+```
+
+---
+
+### Task 7: Final build verification
+
+**Step 1: Clean build**
+
+Run: `cd site && rm -rf dist && pnpm run build`
+Expected: Build succeeds with no errors
+
+**Step 2: Verify no TypeScript errors**
+
+Run: `cd site && pnpm exec astro check`
+Expected: No errors (warnings OK)
+
+**Step 3: Commit all changes (if any remaining)**
+
+```bash
+git status
+# If clean, no commit needed
+```
+
+---
+
+### Post-Implementation: Manual Setup (not automated)
+
+These steps must be done by a human in the browser:
+
+1. **Create "Synnovator Preview" GitHub OAuth App**
+   - Go to: `github.com/organizations/Synnovator/settings/applications` → New OAuth App
+   - Application name: `Synnovator Preview`
+   - Homepage URL: `https://synnovator.pages.dev`
+   - Callback URL: `https://synnovator.pages.dev/api/auth/callback`
+   - Generate client secret, save both Client ID and Secret
+
+2. **Update Cloudflare Pages dashboard**
+   - Settings → Build → Change build command to: `cd site && pnpm run build`
+   - Settings → Build → Set build output directory to: `site/dist`
+   - Settings → Environment Variables → Production:
+     - `SITE_URL` = `https://home.synnovator.space`
+     - `GITHUB_CLIENT_ID` = `Iv23liQaa34mwXMU912V`
+     - `GITHUB_CLIENT_SECRET` = (existing prod secret)
+     - `AUTH_SECRET` = (existing)
+     - `GITHUB_OWNER` = `Synnovator`
+     - `GITHUB_REPO` = `monorepo`
+     - R2 credentials (existing)
+   - Settings → Environment Variables → Preview:
+     - `SITE_URL` = `https://synnovator.pages.dev`
+     - `GITHUB_CLIENT_ID` = (preview app ID from step 1)
+     - `GITHUB_CLIENT_SECRET` = (preview secret from step 1)
+     - `AUTH_SECRET` = (same as production)
+     - `GITHUB_OWNER` = `Synnovator`
+     - `GITHUB_REPO` = `monorepo`
+     - R2 credentials (same as production)
+
+3. **Test** — push a PR branch, verify preview URL works, test OAuth login flow


### PR DESCRIPTION
## Summary
- Archive design and implementation docs from deleted `feat/preview-deploy-oauth` branch
- These docs describe the Astro-era preview deploy OAuth architecture (cross-subdomain cookies, redirect validation)
- Preserved as reference for future Next.js implementation of preview deploy OAuth

## Test plan
- [ ] Verify docs render correctly in `docs/plans/`
- [ ] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)