### PR TITLE
fix(web): robust error handling for submit-pr API

### DIFF
--- a/apps/web/app/api/submit-pr/route.ts
+++ b/apps/web/app/api/submit-pr/route.ts
@@ -20,51 +20,78 @@ const BRANCH_PREFIX: Record<SubmitType, string> = {
   profile: 'data/create-profile',
 };
 
+/** Base64-encode a UTF-8 string (works in both Node.js and Cloudflare Workers). */
+function toBase64(str: string): string {
+  const bytes = new TextEncoder().encode(str);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
 export async function POST(request: NextRequest) {
-  // 1. Auth
-  const session = await getSession(request, process.env.AUTH_SECRET!);
-  if (!session) {
-    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
-  }
-
-  // 2. Parse + validate
-  let body: { type: string; filename: string; content: string; slug: string };
   try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: 'invalid JSON' }, { status: 400 });
-  }
+    // 1. Auth
+    const session = await getSession(request, process.env.AUTH_SECRET!);
+    if (!session) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
 
-  const { type, filename, content, slug } = body;
+    // 2. Parse + validate
+    let body: { type: string; filename: string; content: string; slug: string };
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'invalid JSON' }, { status: 400 });
+    }
 
-  if (!VALID_TYPES.includes(type as SubmitType)) {
-    return NextResponse.json({ error: 'invalid type' }, { status: 400 });
-  }
-  if (!filename || !FILENAME_PATTERNS.some(p => p.test(filename))) {
-    return NextResponse.json({ error: 'invalid filename' }, { status: 400 });
-  }
-  if (!content?.trim()) {
-    return NextResponse.json({ error: 'empty content' }, { status: 400 });
-  }
-  if (!slug?.trim()) {
-    return NextResponse.json({ error: 'missing slug' }, { status: 400 });
-  }
+    const { type, filename, content, slug } = body;
 
-  // 3. Octokit
-  const octokit = getInstallationOctokit({
-    GITHUB_APP_ID: process.env.GITHUB_APP_ID!,
-    GITHUB_APP_PRIVATE_KEY: process.env.GITHUB_APP_PRIVATE_KEY!,
-    GITHUB_APP_INSTALLATION_ID: process.env.GITHUB_APP_INSTALLATION_ID!,
-  });
+    if (!VALID_TYPES.includes(type as SubmitType)) {
+      return NextResponse.json({ error: 'invalid type' }, { status: 400 });
+    }
+    if (!filename || !FILENAME_PATTERNS.some(p => p.test(filename))) {
+      return NextResponse.json({ error: 'invalid filename' }, { status: 400 });
+    }
+    if (!content?.trim()) {
+      return NextResponse.json({ error: 'empty content' }, { status: 400 });
+    }
+    if (!slug?.trim()) {
+      return NextResponse.json({ error: 'missing slug' }, { status: 400 });
+    }
 
-  const submitType = type as SubmitType;
+    // 3. Check required env vars
+    const appId = process.env.GITHUB_APP_ID;
+    const privateKey = process.env.GITHUB_APP_PRIVATE_KEY;
+    const installationId = process.env.GITHUB_APP_INSTALLATION_ID;
+    const missing = [
+      !appId && 'GITHUB_APP_ID',
+      !privateKey && 'GITHUB_APP_PRIVATE_KEY',
+      !installationId && 'GITHUB_APP_INSTALLATION_ID',
+    ].filter(Boolean);
+    if (missing.length) {
+      console.error('submit-pr: missing env vars:', missing.join(', '));
+      return NextResponse.json(
+        { error: `Server configuration error: missing ${missing.join(', ')}` },
+        { status: 500 },
+      );
+    }
 
-  try {
-    // 4a. Get main SHA
+    // 4. Octokit (vars guaranteed non-null after missing check above)
+    const octokit = getInstallationOctokit({
+      GITHUB_APP_ID: appId!,
+      GITHUB_APP_PRIVATE_KEY: privateKey!,
+      GITHUB_APP_INSTALLATION_ID: installationId!,
+    });
+
+    const submitType = type as SubmitType;
+
+    // 5a. Get main SHA
     const { data: ref } = await octokit.git.getRef({ owner: OWNER, repo: REPO, ref: 'heads/main' });
     const mainSha = ref.object.sha;
 
-    // 4b. Create branch (retry with timestamp on conflict)
+    // 5b. Create branch (retry with timestamp on conflict)
     let branchName = `${BRANCH_PREFIX[submitType]}-${slug}`;
     try {
       await octokit.git.createRef({
@@ -86,7 +113,7 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // 4c. Commit file
+    // 5c. Commit file
     const commitMessage =
       submitType === 'hackathon' ? `feat(hackathons): create ${slug}` :
       submitType === 'proposal' ? `feat(submissions): submit ${slug}` :
@@ -96,11 +123,11 @@ export async function POST(request: NextRequest) {
       owner: OWNER, repo: REPO,
       path: filename,
       message: commitMessage,
-      content: Buffer.from(content).toString('base64'),
+      content: toBase64(content),
       branch: branchName,
     });
 
-    // 4d. Create PR
+    // 5d. Create PR
     const { data: pr } = await octokit.pulls.create({
       owner: OWNER, repo: REPO,
       title: commitMessage,

--- a/apps/web/components/forms/CreateHackathonForm.tsx
+++ b/apps/web/components/forms/CreateHackathonForm.tsx
@@ -251,11 +251,17 @@ export function CreateHackathonForm({ lang }: CreateHackathonFormProps) {
           slug: finalSlug,
         }),
       });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || 'Unknown error');
+      const text = await res.text();
+      let data: { pr_url?: string; error?: string };
+      try {
+        data = JSON.parse(text);
+      } catch {
+        throw new Error(text.slice(0, 200) || `Server error (${res.status})`);
+      }
+      if (!res.ok) throw new Error(data.error || `Server error (${res.status})`);
       window.open(data.pr_url, '_blank', 'noopener,noreferrer');
     } catch (e) {
-      setSubmitError(e instanceof Error ? e.message : 'Unknown error');
+      setSubmitError(e instanceof Error ? e.message : t(lang, 'form.common.submit_error'));
     } finally {
       setSubmitting(false);
     }
@@ -655,16 +661,25 @@ export function CreateHackathonForm({ lang }: CreateHackathonFormProps) {
               {t(lang, 'form.create_hackathon.next')}
             </button>
           ) : (
-            <>
+            <div className="flex flex-col items-end gap-3">
               <button type="button" onClick={handleSubmit}
                 disabled={!isLoggedIn || !isStepValid(0) || !isStepValid(1) || !isStepValid(2) || !isStepValid(4) || submitting}
                 className="px-6 py-2 rounded-lg bg-lime-primary text-near-black text-sm font-medium hover:bg-lime-primary/80 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
                 {submitting ? t(lang, 'form.common.submitting') : t(lang, 'form.create_hackathon.submit_pr')} {'\u2192'}
               </button>
               {submitError && (
-                <p className="text-xs text-error mt-2">{submitError}</p>
+                <div className="w-full rounded-lg border border-error/40 bg-error/10 px-4 py-3 text-sm text-error">
+                  <div className="flex items-start justify-between gap-2">
+                    <div>
+                      <p className="font-medium mb-1">{t(lang, 'form.common.submit_error')}</p>
+                      <p className="text-xs text-error/80 break-all">{submitError}</p>
+                    </div>
+                    <button type="button" onClick={() => setSubmitError('')}
+                      className="shrink-0 text-error/60 hover:text-error transition-colors text-lg leading-none">&times;</button>
+                  </div>
+                </div>
               )}
-            </>
+            </div>
           )}
         </div>
       </fieldset>

--- a/apps/web/components/forms/CreateProposalForm.tsx
+++ b/apps/web/components/forms/CreateProposalForm.tsx
@@ -158,11 +158,17 @@ export function CreateProposalForm({ hackathons, lang }: CreateProposalFormProps
           slug: teamSlug,
         }),
       });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || 'Unknown error');
+      const text = await res.text();
+      let data: { pr_url?: string; error?: string };
+      try {
+        data = JSON.parse(text);
+      } catch {
+        throw new Error(text.slice(0, 200) || `Server error (${res.status})`);
+      }
+      if (!res.ok) throw new Error(data.error || `Server error (${res.status})`);
       window.open(data.pr_url, '_blank', 'noopener,noreferrer');
     } catch (e) {
-      setSubmitError(e instanceof Error ? e.message : 'Unknown error');
+      setSubmitError(e instanceof Error ? e.message : t(lang, 'form.common.submit_error'));
     } finally {
       setSubmitting(false);
     }
@@ -401,16 +407,25 @@ export function CreateProposalForm({ hackathons, lang }: CreateProposalFormProps
               {t(lang, 'form.create_proposal.next')}
             </button>
           ) : (
-            <>
+            <div className="flex flex-col items-end gap-3">
               <button type="button" onClick={handleSubmit}
                 disabled={!isLoggedIn || !isStepValid(0) || !isStepValid(1) || !isStepValid(2) || !isStepValid(3) || submitting}
                 className="px-6 py-2 rounded-lg bg-lime-primary text-near-black text-sm font-medium hover:bg-lime-primary/80 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
                 {submitting ? t(lang, 'form.common.submitting') : t(lang, 'form.create_proposal.submit_pr')} {'\u2192'}
               </button>
               {submitError && (
-                <p className="text-xs text-error mt-2">{submitError}</p>
+                <div className="w-full rounded-lg border border-error/40 bg-error/10 px-4 py-3 text-sm text-error">
+                  <div className="flex items-start justify-between gap-2">
+                    <div>
+                      <p className="font-medium mb-1">{t(lang, 'form.common.submit_error')}</p>
+                      <p className="text-xs text-error/80 break-all">{submitError}</p>
+                    </div>
+                    <button type="button" onClick={() => setSubmitError('')}
+                      className="shrink-0 text-error/60 hover:text-error transition-colors text-lg leading-none">&times;</button>
+                  </div>
+                </div>
               )}
-            </>
+            </div>
           )}
         </div>
       </fieldset>

--- a/apps/web/components/forms/ProfileCreateForm.tsx
+++ b/apps/web/components/forms/ProfileCreateForm.tsx
@@ -158,11 +158,17 @@ export function ProfileCreateForm({ lang }: ProfileCreateFormProps) {
           slug: user.login,
         }),
       });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || 'Unknown error');
+      const text = await res.text();
+      let data: { pr_url?: string; error?: string };
+      try {
+        data = JSON.parse(text);
+      } catch {
+        throw new Error(text.slice(0, 200) || `Server error (${res.status})`);
+      }
+      if (!res.ok) throw new Error(data.error || `Server error (${res.status})`);
       window.open(data.pr_url, '_blank', 'noopener,noreferrer');
     } catch (e) {
-      setSubmitError(e instanceof Error ? e.message : 'Unknown error');
+      setSubmitError(e instanceof Error ? e.message : t(lang, 'form.common.submit_error'));
     } finally {
       setSubmitting(false);
     }
@@ -535,7 +541,7 @@ export function ProfileCreateForm({ lang }: ProfileCreateFormProps) {
               {t(lang, 'form.profile.next')}
             </button>
           ) : (
-            <>
+            <div className="flex flex-col items-end gap-3">
               <button
                 type="button"
                 onClick={handleSubmit}
@@ -545,9 +551,18 @@ export function ProfileCreateForm({ lang }: ProfileCreateFormProps) {
                 {submitting ? t(lang, 'form.common.submitting') : t(lang, 'form.profile.submit_pr')} {'\u2192'}
               </button>
               {submitError && (
-                <p className="text-xs text-error mt-2">{submitError}</p>
+                <div className="w-full rounded-lg border border-error/40 bg-error/10 px-4 py-3 text-sm text-error">
+                  <div className="flex items-start justify-between gap-2">
+                    <div>
+                      <p className="font-medium mb-1">{t(lang, 'form.common.submit_error')}</p>
+                      <p className="text-xs text-error/80 break-all">{submitError}</p>
+                    </div>
+                    <button type="button" onClick={() => setSubmitError('')}
+                      className="shrink-0 text-error/60 hover:text-error transition-colors text-lg leading-none">&times;</button>
+                  </div>
+                </div>
               )}
-            </>
+            </div>
           )}
         </div>
       </fieldset>

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -11,6 +11,8 @@
     "SITE_URL": "https://home.synnovator.space",
     "GITHUB_CLIENT_ID": "Iv23liQaa34mwXMU912V",
     "GITHUB_OWNER": "Synnovator",
-    "GITHUB_REPO": "monorepo"
+    "GITHUB_REPO": "monorepo",
+    "GITHUB_APP_ID": "2996003",
+    "GITHUB_APP_INSTALLATION_ID": "115013782"
   }
 }


### PR DESCRIPTION
## Summary
- Wrap entire `/api/submit-pr` route handler in top-level try-catch to prevent empty response crashes
- Add explicit env var validation — returns detailed error listing missing vars (e.g. `missing GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID`)
- Replace `Buffer.from().toString('base64')` with `btoa`-based `toBase64()` for Cloudflare Workers compatibility
- Client-side: use `res.text()` + `JSON.parse()` instead of `res.json()` to gracefully handle non-JSON responses
- Upgrade error display from tiny inline `<p>` to styled alert banner with dismiss button (all 3 forms)
- Add `GITHUB_APP_ID` and `GITHUB_APP_INSTALLATION_ID` to `wrangler.jsonc` vars

## Root Cause
`GITHUB_APP_ID` and `GITHUB_APP_INSTALLATION_ID` were missing from Cloudflare Pages environment, causing the Worker to crash with an empty response. The client's `res.json()` then threw "Unexpected end of JSON input" with no useful error message.

## Test plan
- [ ] Deploy to Cloudflare Pages (ensure `GITHUB_APP_PRIVATE_KEY` secret is set in dashboard)
- [ ] Test create-hackathon form submission → should create PR or show clear error
- [ ] Test create-proposal form submission
- [ ] Test profile creation form submission
- [ ] Verify error alert banner renders with dismiss button on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)