### PR TITLE
refactor(skills): extract simulate and watch-issue as sub-skills

### DIFF
--- a/.claude/skills/synnovator-admin/SKILL.md
+++ b/.claude/skills/synnovator-admin/SKILL.md
@@ -2,13 +2,11 @@
 name: synnovator-admin
 description: >
   Synnovator platform admin CLI — create/update/close hackathons, manage profiles and submissions,
-  export scores and registrations, audit changes and permissions, and simulate full hackathon
-  scenarios with synthetic data, and monitor issues with AI-powered triage. Use whenever the admin
-  needs to manage hackathon data, create profiles, export reports, query audit history, simulate
-  hackathon scenarios, monitor new bug/feature issues, or perform any platform management operation.
-  Also trigger when the user mentions hackathon management, YAML data editing, score exports,
-  NDA approvals, 模拟活动, 生成仿真数据, simulate hackathon, forge challenge scenario,
-  活动虚拟数据, watch issues, or issue triage in the Synnovator context.
+  export scores and registrations, audit changes and permissions. Use whenever the admin needs to
+  manage hackathon data, create profiles, export reports, query audit history, or perform any
+  platform management operation. Also trigger when the user mentions hackathon management, YAML
+  data editing, score exports, or NDA approvals in the Synnovator context. For hackathon simulation
+  use /synnovator-admin:simulate; for issue monitoring use /synnovator-admin:watch-issue.
 ---
 
 # Synnovator Admin
@@ -28,15 +26,15 @@ and PR creation into guided interactive workflows.
 | `create-profile` | Write | Generate hacker profile skeleton, guide editing, PR |
 | `submit-project` | Write | Generate submission skeleton, guide editing, PR |
 | `approve-nda` | Write | Find NDA issue, add `nda-approved` label |
-| `simulate` | Write | Generate full hackathon simulation data (hackathon.yml + profiles + submissions + archive) |
-| `list-registrations` | Read | Query registration issues for a hackathon |
-| `list-submissions` | Read | Scan submission directories and show status |
-| `export-scores` | Read | Parse score issues into CSV |
-| `export-report` | Read | Generate comprehensive activity report |
-| `audit-log` | Read | Query git history for a hackathon |
-| `audit-permissions` | Read | Check RBAC config (collaborators + CODEOWNERS) |
-| `audit-secrets` | Read | Verify required GitHub Secrets are configured |
-| `watch-issue` | Watch | Monitor new bug/feature issues, AI triage + summary |
+
+### Sub-Skills (independent invocation)
+
+| Command | Invocation | What it does |
+|---------|------------|-------------|
+| `simulate` | `/synnovator-admin:simulate` | Generate full hackathon simulation data |
+| `watch-issue` | `/synnovator-admin:watch-issue` | Monitor new bug/feature issues, AI triage + summary |
+
+> **Tip**: `watch-issue` is designed for recurring use: `/loop 30m /synnovator-admin:watch-issue`
 
 When the admin invokes `/synnovator-admin` without a specific command, display this table and
 ask which operation they need.
@@ -139,122 +137,6 @@ After commit, offer to create PR but never push without the admin's confirmation
 5. Add label: `gh issue edit {number} --add-label "nda-approved"`
 6. Add comment: `gh issue comment {number} --body "NDA approved by @{admin}"`
 
-### simulate
-
-Generate a complete hackathon simulation — schema-v2 compliant YAML data files plus a rich
-Markdown archive — using fictional but realistic data. The output is indistinguishable from
-real platform data. Useful for user research interviews, operational dry-runs, demos, and
-pitch materials.
-
-Branch naming: `data/simulate-{slug}`
-
-**Two organizer personas** shape defaults for legal, eligibility, confidentiality, and risk focus:
-
-| Dimension | Enterprise (`enterprise`) | Youth League (`youth-league`) |
-|-----------|--------------------------|-------------------------------|
-| IP | Owned by organizer; NDA required | Open-source or author-owned |
-| Confidentiality | High (NDA + data policy) | Low |
-| Rewards | Cash / pilot contract / procurement | Certificates / internships / honors |
-| Risk focus | R-01–R-05 (data leak, IP infringement) | R-03–R-08 (content violations, credential fraud) |
-
-#### Parameter collection
-
-Guide the admin through these parameters one at a time. The admin can say "use defaults" at
-any step to accept all remaining defaults.
-
-| # | Parameter | Required | Default |
-|---|-----------|----------|---------|
-| 1 | `slug` | Yes | — |
-| 2 | `organizer_type` | Yes | `enterprise` |
-| 3 | `challenge_theme` | Yes | "AI 驱动的智能运营方案探索" |
-| 4 | `participant_scale` | No | `medium` |
-| 5 | `tracks` | No | Technical + Business |
-| 6 | `timeline` | No | 12-week standard (T+7 from today) |
-| 7 | `team_policy` | No | 2–5 members |
-| 8 | `judging_model` | No | Expert only; 4 criteria |
-| 9 | `risk_event_toggles` | No | All enabled |
-| 10 | `random_seed` | No | `42` |
-
-**Scale presets** — `participant_scale` controls how much data to generate:
-
-| Scale | Profiles | Submissions | Visitors | Registrations |
-|-------|----------|-------------|----------|---------------|
-| `small` | 5–8 | 3–5 | ~1,500 | ~100 |
-| `medium` | 15–20 | 8–12 | ~5,000 | ~300 |
-| `large` | 30–40 | 15–20 | ~15,000 | ~800 |
-
-#### Execution steps
-
-1. **Confirm persona** — `organizer_type` selects default legal/eligibility/risk settings
-2. **Create branch** — `git checkout -b data/simulate-{slug}`
-3. **Generate `hackathon.yml`**
-   - Read `references/schema-v2.md` for field structure
-   - Read `references/simulate-output-template.md` for content richness guidance
-   - Fill `legal`, `eligibility`, `settings` per `organizer_type`
-   - Generate fictional organizers, judges, events, FAQ, datasets (enterprise)
-   - Enterprise: `legal.nda.required: true`, `ip_ownership: organizer`, compliance notes
-   - Youth-league: `eligibility.open_to: students`, `legal.license: Apache-2.0`, mentor rules
-4. **Generate profiles** — create `profiles/{username}-{uuid}.yml` files
-   - Count per `participant_scale` table above
-   - Fictional Chinese names, natural backgrounds, varied skills and experience levels
-   - Each file conforms to profile schema in `references/schema-v2.md`
-5. **Generate submissions** — create `hackathons/{slug}/submissions/team-{name}/project.yml`
-   - Count per `participant_scale` table above
-   - Team members drawn from generated profiles (each profile used at most once)
-   - Cover all tracks; varied deliverable types (repo, video, demo, document)
-6. **Generate `simulation-archive.md`** — the rich Markdown companion document
-   - Read `references/simulate-output-template.md` and follow chapters 0–7 exactly
-   - Read `references/simulate-risk-playbook.md` and inject ≥5 risk scenarios into chapter 5
-   - Include: funnel data, ≥12 post samples (8+ types), scoring sheets, KPI dashboard
-   - Read `references/simulate-example-a.md` or `simulate-example-b.md` if admin requests examples
-7. **Self-consistency check** — verify before committing:
-   - Funnel: visitors > registrations > teams > submissions > winners (monotonic decrease)
-   - Profile count ≥ total unique team members across all submissions
-   - Judging criteria weights sum to 1.0 (±0.01) per track
-   - Timeline stages are chronological with no overlaps
-   - Weighted scores in archive calculate correctly
-8. **Validate** — `bash scripts/validate-hackathon.sh hackathons/{slug}/hackathon.yml`
-9. **Review** — list all generated files for admin inspection
-10. **Commit** — single commit with all files:
-    ```bash
-    git add hackathons/{slug}/ profiles/
-    git commit -m "feat(hackathons): simulate hackathon {slug}"
-    ```
-11. **Offer PR**
-
-#### Data generation rules
-
-- **Natural numbers** — avoid round alignment (use 317, not 300; 4,312, not 4,000)
-- **Fictional identifiers** — Chinese names (陈梦阳, 李思远), companies (智海科技, 云擎网络),
-  placeholder URLs (`https://github.com/synnovator-demo/proj-xxx`)
-- **Persona-specific** — enterprise archives emphasize NDA/IP/data policy;
-  youth-league archives emphasize student eligibility and mentor rules
-- **Post diversity** — ≥12 sample posts covering: official announcements, technical Q&A,
-  experience sharing, complaints, team recruitment, mentor Q&A, celebrations, appeals
-- **No real PII** — no real phone numbers, ID numbers, or registered company names
-
-#### Quality checklist
-
-Before committing, verify:
-- [ ] `hackathon.yml` passes `validate-hackathon.sh`
-- [ ] Funnel numbers decrease monotonically in `simulation-archive.md`
-- [ ] Profile count matches `participant_scale`
-- [ ] Submissions ≥ 8 (for medium/large), team members all have profiles
-- [ ] Weighted scoring totals calculate correctly
-- [ ] Risk scenarios ≥ 5 types in `simulation-archive.md`
-- [ ] Enterprise: NDA + IP clauses present / Youth-league: open-source license declared
-- [ ] No real personally identifiable information anywhere
-
-#### Reference files
-
-| File | When to load |
-|------|-------------|
-| `references/schema-v2.md` | Always — YAML field structure for hackathon, profile, submission |
-| `references/simulate-output-template.md` | Always — chapters 0–7 structure for simulation-archive.md |
-| `references/simulate-risk-playbook.md` | Step 6 — risk scenarios for chapter 5 |
-| `references/simulate-example-a.md` | On request — medium-small enterprise pilot example |
-| `references/simulate-example-b.md` | On request — large-scale youth-league competition example |
-
 ---
 
 ## Read Operations
@@ -332,56 +214,11 @@ and JSON parsing.
 
 ---
 
-## Watch Operations
-
-### watch-issue
-
-Monitor new Bug Reports and Feature Requests, perform AI-powered triage, and post summary comments.
-
-**Invocation**: `/loop 30m /synnovator-admin:watch-issue`
-
-**Prerequisite**: `/loop` is a Claude Code built-in skill that repeats a slash command at the specified interval. The loop runs in the local Claude Code session and stops when the session closes.
-
-**Execution steps**:
-
-1. **Query new issues** — read `references/github-api-patterns.md` for the exact queries:
-   ```bash
-   gh issue list --label "bug" --label "triaged" --state open --search "-label:watched" --json number,title,author,createdAt,body,labels --limit 50
-   gh issue list --label "enhancement" --label "triaged" --state open --search "-label:watched" --json number,title,author,createdAt,body,labels --limit 50
-   ```
-
-2. **For each issue**:
-   a. Parse the issue body to extract form field values
-   b. Read `references/watch-issue-prompt.md` for the AI triage prompt structure
-   c. Analyze the issue and generate a triage summary
-   d. Post the triage summary as a comment: `gh issue comment {number} --body "{summary}"`
-   e. Add the `watched` label: `gh issue edit {number} --add-label "watched"`
-
-3. **Output scan report** to the terminal:
-   ```
-   ━━━ watch-issue 扫描报告 ━━━
-     扫描时间：{timestamp}
-     新 Bug：{count} 个 | 新 Feature：{count} 个
-
-     #{number} [{priority} {type}] {title summary} — @{author}
-          → 影响：{impact} | 模块：{module}
-
-     无需处理：{count} 个（已有摘要或待补充信息）
-   ━━━━━━━━━━━━━━━━━━━━━━━━━━━
-   ```
-
-4. **If no new issues found**, output:
-   ```
-   ━━━ watch-issue 扫描报告 ━━━
-     扫描时间：{timestamp}
-     无新 Issue 需要处理
-   ━━━━━━━━━━━━━━━━━━━━━━━━━━━
-   ```
-
----
-
 ## Important Rules
 
+- **All `references/` paths are relative to this skill's base directory** (provided by the
+  system as `Base directory for this skill:` at load time), not the project root — always
+  resolve via the skill directory when using the Read tool
 - Use `pnpm` for any JavaScript tooling — never `npm` or `npx` (enforced by hook)
 - Always show generated/modified files for review before committing
 - Never commit directly to `main` — always create a feature branch and PR

--- a/.claude/skills/synnovator-admin/simulate/SKILL.md
+++ b/.claude/skills/synnovator-admin/simulate/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: simulate
+description: >
+  Generate a complete hackathon simulation with schema-v2 compliant YAML data and rich Markdown
+  archive using fictional but realistic data. Use when the admin mentions: simulate hackathon,
+  forge challenge scenario, 模拟活动, 生成仿真数据, 活动虚拟数据, operational dry-run, demo data,
+  or pitch materials. Also trigger for requests involving synthetic hackathon data generation
+  at any scale (small/medium/large).
+---
+
+# Simulate Hackathon
+
+Generate a complete hackathon simulation — schema-v2 compliant YAML data files plus a rich
+Markdown archive — using fictional but realistic data. The output is indistinguishable from
+real platform data. Useful for user research interviews, operational dry-runs, demos, and
+pitch materials.
+
+> **References path**: All `references/` paths resolve to `../references/` relative to this file
+> (the parent skill's shared reference directory).
+
+> **Shared rules**: Branch naming, commit format, validation, and other conventions follow
+> the parent skill's Important Rules — see `../SKILL.md`.
+
+Branch naming: `data/simulate-{slug}`
+
+## Organizer Personas
+
+**Two organizer personas** shape defaults for legal, eligibility, confidentiality, and risk focus:
+
+| Dimension | Enterprise (`enterprise`) | Youth League (`youth-league`) |
+|-----------|--------------------------|-------------------------------|
+| IP | Owned by organizer; NDA required | Open-source or author-owned |
+| Confidentiality | High (NDA + data policy) | Low |
+| Rewards | Cash / pilot contract / procurement | Certificates / internships / honors |
+| Risk focus | R-01–R-05 (data leak, IP infringement) | R-03–R-08 (content violations, credential fraud) |
+
+## Parameter Collection
+
+Guide the admin through these parameters one at a time. The admin can say "use defaults" at
+any step to accept all remaining defaults.
+
+| # | Parameter | Required | Default |
+|---|-----------|----------|---------|
+| 1 | `slug` | Yes | — |
+| 2 | `organizer_type` | Yes | `enterprise` |
+| 3 | `challenge_theme` | Yes | "AI 驱动的智能运营方案探索" |
+| 4 | `participant_scale` | No | `medium` |
+| 5 | `tracks` | No | Technical + Business |
+| 6 | `timeline` | No | 12-week standard (T+7 from today) |
+| 7 | `team_policy` | No | 2–5 members |
+| 8 | `judging_model` | No | Expert only; 4 criteria |
+| 9 | `risk_event_toggles` | No | All enabled |
+| 10 | `random_seed` | No | `42` |
+
+**Scale presets** — `participant_scale` controls how much data to generate:
+
+| Scale | Profiles | Submissions | Visitors | Registrations |
+|-------|----------|-------------|----------|---------------|
+| `small` | 5–8 | 3–5 | ~1,500 | ~100 |
+| `medium` | 15–20 | 8–12 | ~5,000 | ~300 |
+| `large` | 30–40 | 15–20 | ~15,000 | ~800 |
+
+## Execution Steps
+
+1. **Confirm persona** — `organizer_type` selects default legal/eligibility/risk settings
+2. **Create branch** — `git checkout -b data/simulate-{slug}`
+3. **Generate `hackathon.yml`**
+   - Read `references/schema-v2.md` for field structure
+   - Read `references/simulate-output-template.md` for content richness guidance
+   - Fill `legal`, `eligibility`, `settings` per `organizer_type`
+   - Generate fictional organizers, judges, events, FAQ, datasets (enterprise)
+   - Enterprise: `legal.nda.required: true`, `ip_ownership: organizer`, compliance notes
+   - Youth-league: `eligibility.open_to: students`, `legal.license: Apache-2.0`, mentor rules
+4. **Generate profiles** — create `profiles/{username}-{uuid}.yml` files
+   - Count per `participant_scale` table above
+   - Fictional Chinese names, natural backgrounds, varied skills and experience levels
+   - Each file conforms to profile schema in `references/schema-v2.md`
+5. **Generate submissions** — create `hackathons/{slug}/submissions/team-{name}/project.yml`
+   - Count per `participant_scale` table above
+   - Team members drawn from generated profiles (each profile used at most once)
+   - Cover all tracks; varied deliverable types (repo, video, demo, document)
+6. **Generate `simulation-archive.md`** — the rich Markdown companion document
+   - Read `references/simulate-output-template.md` and follow chapters 0–7 exactly
+   - Read `references/simulate-risk-playbook.md` and inject ≥5 risk scenarios into chapter 5
+   - Include: funnel data, ≥12 post samples (8+ types), scoring sheets, KPI dashboard
+   - Read `references/simulate-example-a.md` or `simulate-example-b.md` if admin requests examples
+7. **Self-consistency check** — verify before committing:
+   - Funnel: visitors > registrations > teams > submissions > winners (monotonic decrease)
+   - Profile count ≥ total unique team members across all submissions
+   - Judging criteria weights sum to 1.0 (±0.01) per track
+   - Timeline stages are chronological with no overlaps
+   - Weighted scores in archive calculate correctly
+8. **Validate** — `bash scripts/validate-hackathon.sh hackathons/{slug}/hackathon.yml`
+9. **Review** — list all generated files for admin inspection
+10. **Commit** — single commit with all files:
+    ```bash
+    git add hackathons/{slug}/ profiles/
+    git commit -m "feat(hackathons): simulate hackathon {slug}"
+    ```
+11. **Offer PR**
+
+## Data Generation Rules
+
+- **Natural numbers** — avoid round alignment (use 317, not 300; 4,312, not 4,000)
+- **Fictional identifiers** — Chinese names (陈梦阳, 李思远), companies (智海科技, 云擎网络),
+  placeholder URLs (`https://github.com/synnovator-demo/proj-xxx`)
+- **Persona-specific** — enterprise archives emphasize NDA/IP/data policy;
+  youth-league archives emphasize student eligibility and mentor rules
+- **Post diversity** — ≥12 sample posts covering: official announcements, technical Q&A,
+  experience sharing, complaints, team recruitment, mentor Q&A, celebrations, appeals
+- **No real PII** — no real phone numbers, ID numbers, or registered company names
+
+## Quality Checklist
+
+Before committing, verify:
+- [ ] `hackathon.yml` passes `validate-hackathon.sh`
+- [ ] Funnel numbers decrease monotonically in `simulation-archive.md`
+- [ ] Profile count matches `participant_scale`
+- [ ] Submissions ≥ 8 (for medium/large), team members all have profiles
+- [ ] Weighted scoring totals calculate correctly
+- [ ] Risk scenarios ≥ 5 types in `simulation-archive.md`
+- [ ] Enterprise: NDA + IP clauses present / Youth-league: open-source license declared
+- [ ] No real personally identifiable information anywhere
+
+## Reference Files
+
+| File | When to load |
+|------|-------------|
+| `references/schema-v2.md` | Always — YAML field structure for hackathon, profile, submission |
+| `references/simulate-output-template.md` | Always — chapters 0–7 structure for simulation-archive.md |
+| `references/simulate-risk-playbook.md` | Step 6 — risk scenarios for chapter 5 |
+| `references/simulate-example-a.md` | On request — medium-small enterprise pilot example |
+| `references/simulate-example-b.md` | On request — large-scale youth-league competition example |

--- a/.claude/skills/synnovator-admin/watch-issue/SKILL.md
+++ b/.claude/skills/synnovator-admin/watch-issue/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: watch-issue
+description: >
+  Monitor new Bug Report and Feature Request issues with AI-powered triage. Posts summary comments
+  and adds watched labels. Designed for recurring use via /loop. Use when the admin mentions:
+  watch issues, issue triage, monitor bugs, 监控 Issue, issue 分诊, or wants to set up automated
+  issue monitoring in the Synnovator context.
+---
+
+# Watch Issue
+
+Monitor new Bug Reports and Feature Requests, perform AI-powered triage, and post summary comments.
+
+> **References path**: All `references/` paths resolve to `../references/` relative to this file
+> (the parent skill's shared reference directory).
+
+**Invocation**: `/loop 30m /synnovator-admin:watch-issue`
+
+**Prerequisite**: `/loop` is a Claude Code built-in skill that repeats a slash command at the
+specified interval. The loop runs in the local Claude Code session and stops when the session closes.
+
+## Execution Steps
+
+1. **Query new issues** — read `references/github-api-patterns.md` for the exact queries:
+   ```bash
+   gh issue list --label "bug" --label "triaged" --state open --search "-label:watched" --json number,title,author,createdAt,body,labels --limit 50
+   gh issue list --label "enhancement" --label "triaged" --state open --search "-label:watched" --json number,title,author,createdAt,body,labels --limit 50
+   ```
+
+2. **For each issue**:
+   a. Parse the issue body to extract form field values
+   b. Read `references/watch-issue-prompt.md` for the AI triage prompt structure
+   c. Analyze the issue and generate a triage summary
+   d. Post the triage summary as a comment: `gh issue comment {number} --body "{summary}"`
+   e. Add the `watched` label: `gh issue edit {number} --add-label "watched"`
+
+3. **Output scan report** to the terminal:
+   ```
+   ━━━ watch-issue 扫描报告 ━━━
+     扫描时间：{timestamp}
+     新 Bug：{count} 个 | 新 Feature：{count} 个
+
+     #{number} [{priority} {type}] {title summary} — @{author}
+          → 影响：{impact} | 模块：{module}
+
+     无需处理：{count} 个（已有摘要或待补充信息）
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   ```
+
+4. **If no new issues found**, output:
+   ```
+   ━━━ watch-issue 扫描报告 ━━━
+     扫描时间：{timestamp}
+     无新 Issue 需要处理
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   ```


### PR DESCRIPTION
## Summary

- Extract `simulate` (115 lines) and `watch-issue` (43 lines) from main `synnovator-admin/SKILL.md` into independent sub-skills
- Enables colon-syntax invocation: `/synnovator-admin:simulate`, `/synnovator-admin:watch-issue`
- Main SKILL.md reduced from 397 → 231 lines (-42%), keeping write/read ops inline
- `watch-issue` now works natively with `/loop 30m /synnovator-admin:watch-issue`
- Added `references/` path resolution note to prevent root-vs-skill-dir confusion

## Structure after

```
synnovator-admin/
├── SKILL.md              ← Router (Quick Ref + write/read ops + rules)
├── simulate/SKILL.md     ← /synnovator-admin:simulate
├── watch-issue/SKILL.md  ← /synnovator-admin:watch-issue
└── references/           ← Shared (unchanged)
```

## Test plan

- [ ] `/synnovator-admin` shows updated Quick Reference with sub-skill table
- [ ] `/synnovator-admin:simulate` loads simulate sub-skill correctly
- [ ] `/synnovator-admin:watch-issue` loads watch-issue sub-skill correctly
- [ ] `/loop 30m /synnovator-admin:watch-issue` works for recurring monitoring
- [ ] `/synnovator-admin create-hackathon` still works (write ops unchanged)
- [ ] `/synnovator-admin audit-secrets` still works (read ops unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)