### PR TITLE
refactor(skills): enhance watch-issue with two-phase triage

### DIFF
--- a/.claude/skills/synnovator-admin/references/watch-issue-prompt.md
+++ b/.claude/skills/synnovator-admin/references/watch-issue-prompt.md
@@ -1,6 +1,8 @@
 # Watch-Issue AI Triage Prompt
 
-When analyzing a Bug Report or Feature Request issue, generate a triage summary following this structure.
+When analyzing a Bug Report or Feature Request issue, generate triage comments in two phases.
+The goal is to **add information the issue author doesn't have** and **serve the right audience
+at the right time**.
 
 ## Input
 
@@ -12,42 +14,171 @@ You receive the issue's:
 - `labels`: Current labels
 - `createdAt`: Creation timestamp
 
-## Analysis Steps
+Plus:
+- Findings from the codebase investigation (files read, code paths traced)
+- Screenshots from visual verification (if captured)
 
-1. **Classify** the issue into one of:
+---
+
+## Phase 1 — 产品/运营视角
+
+**Audience**: Issue author (usually non-technical), product managers, operations.
+**Tone**: Business language. No code references, no file paths, no technical jargon.
+**When**: Posted immediately when a new triaged issue is found.
+
+### Analysis Steps
+
+1. **Classify** the issue:
    - Bug: UI Bug / 数据问题 / 功能缺陷 / API 错误
    - Feature: 新功能 / 功能增强 / 体验优化
 
-2. **Identify impact** — which pages, modules, or user flows are affected
-
-3. **Assess priority**:
+2. **Assess priority**:
    - P0 紧急: Data loss, security, or complete feature breakage for all users
    - P1 高: Major feature broken for some users, no workaround
    - P2 中: Feature partially broken, workaround exists
    - P3 低: Minor cosmetic issue, enhancement nice-to-have
 
-4. **Map to codebase modules**: `apps/web` / `packages/shared` / `packages/ui` / `hackathons/` / `profiles/` / `scripts/` / `.github/workflows/`
+3. **Assess necessity** (from codebase investigation, described in plain language):
+   - Is this a real gap or a misunderstanding of existing behavior?
+   - Does a workaround exist that the author may not know about?
+   - Is this aligned with the platform's direction?
 
-5. **Extract reproduction path** — key steps for agent-browser to reproduce (Bug only)
+4. **Propose high-level options** (2-3 approaches described in user terms):
+   - Each option: what changes for the user, rough effort level (小/中/大), trade-offs
+   - No code, no file names — describe in terms of user experience
 
-## Output Template
+5. **Ask for confirmation** — @mention the issue author
 
-The comment posted to the issue:
+### Screenshot Integration
+
+Screenshots are embedded **inline within the relevant section**, not grouped at the end.
+Place them where they add the most context:
+
+- **For bugs**: embed in "现状" to show the actual error, and optionally in "我们的理解"
+  to show the normal flow for comparison
+- **For features**: embed in "现状" to show what the platform currently looks like at the
+  relevant point in the flow
+
+When screenshots are available, use:
+```markdown
+![{brief description}]({url})
+```
+
+When screenshots could not be captured, use a text description block:
+```markdown
+> 📸 **{场景}**：{what the screen shows at this point}
+```
+
+### Output Template
 
 ```markdown
-## Issue 分诊摘要
+## 🏥 Issue 分诊
 
-**分类**：{classification}
-**影响范围**：{affected pages/modules}
-**优先级建议**：{P0-P3} — {one-line rationale}
-**关联模块**：{codebase modules}
+**分类**：{Bug/Feature} — {sub-classification}
+**优先级**：{P0-P3} — {one-line rationale}
 
-### 摘要
-{2-3 sentences summarizing the problem/request and its impact}
+### 我们的理解
 
-### 复现关键路径
-{For bugs: numbered steps extracted from issue. For features: N/A}
+{1-2 sentences restating the core problem/request in the team's own words — NOT a copy
+of the issue content. Show that you understood the underlying need, not just the surface.}
+
+### 现状
+
+{What the platform currently does in this area, described for a non-technical reader.
+Mention any existing workarounds or partial solutions the author may not be aware of.
+Base this on the codebase investigation but express in plain language.
+
+Embed screenshot(s) here to visually show the current state.
+For bugs: show the error state. For features: show what exists today.}
+
+### 是否需要做
+
+{Clear judgment: 需要 / 暂缓 / 需要更多信息. One sentence explaining why.}
+
+### 可能的方向
+
+| 方向 | 用户体验变化 | 工作量 |
+|------|-------------|--------|
+| A. {option} | {what changes for the user} | {小/中/大} |
+| B. {option} | {what changes for the user} | {小/中/大} |
+| C. {option} | {what changes for the user} | {小/中/大} |
+
+@{author} 请确认以上理解是否准确？你更倾向哪个方向？
+```
+
+### Phase 1 Quality Checklist
+
+- [ ] Written for a non-technical reader — no code, file paths, or component names
+- [ ] "我们的理解" is NOT a paraphrase of the issue — it shows deeper understanding
+- [ ] "现状" is based on actual codebase findings, not speculation
+- [ ] "现状" includes screenshot(s) or 📸 text description of the current state
+- [ ] Options are described in terms of user experience changes, not implementation
+- [ ] @mentions the issue author for confirmation
 
 ---
-> 讨论达成一致后，请 @allenwoods 确认最终方案。
+
+## Phase 2 — 开发视角
+
+**Audience**: Developers, technical team members, @allenwoods.
+**Tone**: Technical, with specific code references.
+**When**: Posted only after the issue receives `solution-confirmed` label (product discussion
+has concluded and a direction is chosen).
+
+Phase 2 does **not** use agent-browser screenshots — developers benefit more from code
+references than UI screenshots.
+
+### Analysis Steps
+
+1. **Review discussion** — read all comments to understand the confirmed direction
+
+2. **Analyze current state** (from codebase investigation):
+   - What does the current code actually do in this flow?
+   - For bugs: root cause with specific file paths and line numbers
+   - For features: what exists, what's missing, what needs to change
+
+3. **Map the confirmed direction to implementation**:
+   - Which files/modules need changes
+   - Estimated complexity per component
+   - Dependencies and risks
+
+4. **Propose implementation options** (2-3 concrete approaches):
+   - Each option: files to change, complexity (低/中/高), what it solves and what it doesn't
+   - Quick fix vs proper fix if applicable
+
+5. **Recommend** — state a clear suggestion aligned with the confirmed direction
+
+### Output Template
+
+```markdown
+## 🔧 开发方案
+
+**确认方向**：{the solution direction confirmed in Phase 1 discussion}
+**关联模块**：{codebase modules with file paths}
+
+### 根因分析
+
+{For bugs: specific code path, file:line, what goes wrong and why.
+For features: what currently exists, what's missing, architectural context.}
+
+### 实现方案
+
+| 方案 | 改动范围 | 复杂度 | 效果 |
+|------|----------|--------|------|
+| A. {option} | {files/modules} | {低/中/高} | {what it solves} |
+| B. {option} | {files/modules} | {低/中/高} | {what it solves} |
+
+### 建议
+
+{Which option, why, and implementation order. Note any dependencies or risks.}
+
+---
+> 请 @allenwoods 确认最终开发方案。
 ```
+
+### Phase 2 Quality Checklist
+
+- [ ] References specific files and code paths from the investigation
+- [ ] Implementation options are concrete (not "refactor the module" but "change X in file Y")
+- [ ] Aligned with the solution direction confirmed in Phase 1 discussion
+- [ ] Includes a clear, specific recommendation
+- [ ] @mentions @allenwoods for final confirmation

--- a/.claude/skills/synnovator-admin/watch-issue/SKILL.md
+++ b/.claude/skills/synnovator-admin/watch-issue/SKILL.md
@@ -19,7 +19,21 @@ Monitor new Bug Reports and Feature Requests, perform AI-powered triage, and pos
 **Prerequisite**: `/loop` is a Claude Code built-in skill that repeats a slash command at the
 specified interval. The loop runs in the local Claude Code session and stops when the session closes.
 
+## Two-Phase Triage Model
+
+Triage comments are split into two phases to serve different audiences:
+
+- **Phase 1 — 产品/运营视角**: Non-technical, posted immediately. Focuses on user impact,
+  necessity judgment, and high-level options in business language. Includes visual evidence
+  (screenshots) when possible. @mentions the issue author for confirmation.
+- **Phase 2 — 开发视角**: Technical, posted only after product discussion concludes (triggered
+  by `solution-confirmed` label). Contains code references, root cause analysis, and
+  implementation recommendations. @mentions @allenwoods for final confirmation and adds
+  `discussion-completed` label.
+
 ## Execution Steps
+
+### Scan A — New Issues (Phase 1)
 
 1. **Query new issues** — read `references/github-api-patterns.md` for the exact queries:
    ```bash
@@ -28,26 +42,117 @@ specified interval. The loop runs in the local Claude Code session and stops whe
    ```
 
 2. **For each issue**:
-   a. Parse the issue body to extract form field values
-   b. Read `references/watch-issue-prompt.md` for the AI triage prompt structure
-   c. Analyze the issue and generate a triage summary
-   d. Post the triage summary as a comment: `gh issue comment {number} --body "{summary}"`
-   e. Add the `watched` label: `gh issue edit {number} --add-label "watched"`
 
-3. **Output scan report** to the terminal:
+   a. Parse the issue body to extract form field values
+
+   b. **Investigate the codebase** — this is the critical step that turns triage from paraphrase
+      into analysis:
+      - From the issue content, identify which user flow / page / module is involved
+      - Use Glob and Grep to locate the relevant source files
+      - Read the key files to understand **what the current code actually does**
+      - For bugs: trace the code path to identify where the failure likely occurs
+      - For features: check whether the requested behavior (or a partial version) already exists
+
+   c. **Visual verification (best-effort)** — use `agent-browser` to capture the current state.
+      This step is best-effort: if the app is inaccessible, requires special auth, or the flow
+      cannot be triggered, skip and proceed with text-only triage.
+
+      **Target URL**: `https://home.synnovator.space/` (production) or `http://localhost:3000`
+      (dev, if running). Prefer production for accuracy.
+
+      **What to capture**:
+
+      - **For bugs** — follow the reproduction steps from the issue:
+        1. Screenshot the starting state (the page before the action)
+        2. Perform the action that triggers the bug
+        3. Screenshot the error / unexpected result
+        4. If applicable, screenshot what a normal/expected state looks like for comparison
+
+      - **For features** — capture the current flow to illustrate "现状":
+        1. Screenshot the relevant page in its current state
+        2. If the feature is about a flow (e.g., creation → submission), screenshot key steps
+        3. Highlight the moment where the gap exists (e.g., "after submission, this is all the
+           user sees")
+
+      **Screenshot naming**: `issue-{number}-{step}.png` (e.g., `issue-61-error.png`)
+
+      **Embedding screenshots in GitHub comments**:
+      Upload each screenshot and collect the resulting URLs. Then embed in the comment as:
+      ```markdown
+      ![{description}]({url})
+      ```
+
+      **Upload mechanism** (in order of preference):
+      1. Use GitHub's user-content upload if available
+      2. Upload to the repo via Contents API on an `assets/screenshots` branch:
+         ```bash
+         BASE64=$(base64 < screenshot.png | tr -d '\n')
+         URL=$(gh api repos/{owner}/{repo}/contents/.github/screenshots/issue-{number}-{name}.png \
+           --method PUT \
+           -f message="chore: screenshot for #{number}" \
+           -f content="$BASE64" \
+           -f branch="assets/screenshots" \
+           --jq '.content.download_url')
+         ```
+      3. **Fallback**: if upload is not feasible, use text description blocks:
+         ```markdown
+         > 📸 **{场景描述}**：{what was observed on screen}
+         ```
+
+   d. Read `references/watch-issue-prompt.md` for the Phase 1 triage prompt structure
+
+   e. Generate a **Phase 1 comment** (product/ops perspective) that includes:
+      - Necessity assessment in business terms
+      - Whether existing alternatives or workarounds exist
+      - High-level options described without code jargon
+      - Screenshots or visual descriptions embedded in relevant sections
+      - @mention the issue author asking for confirmation
+
+   f. Post the Phase 1 comment: `gh issue comment {number} --body "{summary}"`
+
+   g. Add the `watched` label: `gh issue edit {number} --add-label "watched"`
+
+### Scan B — Solution-Confirmed Issues (Phase 2)
+
+3. **Query issues ready for Phase 2**:
+   ```bash
+   gh issue list --label "solution-confirmed" --state open --search "-label:discussion-completed" --json number,title,author,createdAt,body,labels --limit 50
+   ```
+
+4. **For each issue**:
+   a. Read the issue body and all comments to understand the product discussion outcome
+   b. If not already investigated, perform codebase investigation (same as step 2b)
+   c. Read `references/watch-issue-prompt.md` for the Phase 2 triage prompt structure
+   d. Generate a **Phase 2 comment** (developer perspective) that includes:
+      - Code references with specific file paths
+      - Root cause analysis (for bugs) or implementation assessment (for features)
+      - Concrete implementation options with complexity and module scope
+      - Clear recommendation aligned with the confirmed solution direction
+   e. Post the Phase 2 comment: `gh issue comment {number} --body "{summary}"`
+   f. Add the `discussion-completed` label: `gh issue edit {number} --add-label "discussion-completed"`
+   g. @mention @allenwoods in the comment for final confirmation
+
+### Scan Report
+
+5. **Output scan report** to the terminal:
    ```
    ━━━ watch-issue 扫描报告 ━━━
      扫描时间：{timestamp}
-     新 Bug：{count} 个 | 新 Feature：{count} 个
+     Phase 1 — 新 Bug：{count} 个 | 新 Feature：{count} 个
 
      #{number} [{priority} {type}] {title summary} — @{author}
-          → 影响：{impact} | 模块：{module}
+          → 影响：{impact} | 📸 {有截图/仅文字}
 
-     无需处理：{count} 个（已有摘要或待补充信息）
+     Phase 2 — 待开发确认：{count} 个
+
+     #{number} [{type}] {title summary}
+          → 确认方案：{solution direction}
+
+     无需处理：{count} 个
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━
    ```
 
-4. **If no new issues found**, output:
+6. **If no new issues found in either scan**, output:
    ```
    ━━━ watch-issue 扫描报告 ━━━
      扫描时间：{timestamp}

--- a/.github/workflows/validate-bug.yml
+++ b/.github/workflows/validate-bug.yml
@@ -2,7 +2,7 @@ name: Validate Bug Report
 
 on:
   issues:
-    types: [opened, edited, labeled]
+    types: [edited, labeled]
 
 jobs:
   validate:
@@ -119,6 +119,6 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: '✅ **Bug Report 验证通过。** 感谢提交！团队将尽快查看。\n\n> 讨论达成一致后，请 @allenwoods 确认最终方案。',
+                body: '✅ **Bug Report 验证通过。** 感谢提交！团队将尽快查看。',
               });
             }

--- a/.github/workflows/validate-feature.yml
+++ b/.github/workflows/validate-feature.yml
@@ -2,7 +2,7 @@ name: Validate Feature Request
 
 on:
   issues:
-    types: [opened, edited, labeled]
+    types: [edited, labeled]
 
 jobs:
   validate:
@@ -107,6 +107,6 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: '✅ **Feature Request 验证通过。** 感谢建议！团队将评估可行性。\n\n> 讨论达成一致后，请 @allenwoods 确认最终方案。',
+                body: '✅ **Feature Request 验证通过。** 感谢建议！团队将评估可行性。',
               });
             }

--- a/.github/workflows/validate-nda.yml
+++ b/.github/workflows/validate-nda.yml
@@ -2,7 +2,7 @@ name: Validate NDA
 
 on:
   issues:
-    types: [opened, edited, labeled]
+    types: [edited, labeled]
 
 jobs:
   validate:

--- a/.github/workflows/validate-register.yml
+++ b/.github/workflows/validate-register.yml
@@ -2,7 +2,7 @@ name: Validate Registration
 
 on:
   issues:
-    types: [opened, edited, labeled]
+    types: [edited, labeled]
 
 jobs:
   validate:


### PR DESCRIPTION
## Summary

- **Two-phase triage model**: Phase 1 (product/ops, non-technical) posts immediately; Phase 2 (developer, technical) triggers only after `solution-confirmed` label is added
- **Visual verification**: Integrates `agent-browser` screenshots into Phase 1 comments (best-effort, with text fallback)
- **Fix duplicate validation comments**: Remove `opened` from issue event triggers in 4 workflows (`validate-bug`, `validate-feature`, `validate-register`, `validate-nda`) — GitHub fires both `opened` and `labeled` when an issue is created with a pre-selected label
- **Conditional @mention strategy**: @author in Phase 1 for confirmation, @allenwoods in Phase 2 for final dev sign-off (via `discussion-completed` label)
- **Remove hardcoded footer**: "讨论达成一致后，请 @allenwoods 确认最终方案" removed from validation workflow comments — this responsibility moves to Phase 2 triage

## Test plan

- [ ] Create a test Bug Report issue → verify only 1 validation comment appears (not 2)
- [ ] Run `/synnovator-admin watch-issue` → verify Phase 1 comment is non-technical with @author mention
- [ ] Add `solution-confirmed` label to an issue → run watch-issue again → verify Phase 2 comment has code references and @allenwoods mention
- [ ] Verify `agent-browser` screenshot capture works on `https://home.synnovator.space/` (or gracefully falls back to text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)