### PR TITLE
fix(web): fix YAML formatting bug and add validation safeguards

### DIFF
--- a/.github/workflows/validate-hackathon.yml
+++ b/.github/workflows/validate-hackathon.yml
@@ -6,6 +6,10 @@ on:
       - 'hackathons/**/hackathon.yml'
       - 'docs/templates/**/hackathon.yml'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -28,18 +32,41 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Validate hackathon YAML files
+        id: validate
         run: |
           FAILED=0
+          ERRORS=""
           while IFS= read -r file; do
             [ -z "$file" ] && continue
             echo "─── Validating $file ───"
-            if ! bash scripts/validate-hackathon.sh "$file"; then
+            OUTPUT=$(bash scripts/validate-hackathon.sh "$file" 2>&1) || {
               FAILED=1
-            fi
+              ERRORS="${ERRORS}${OUTPUT}"$'\n'
+            }
+            echo "$OUTPUT"
           done <<< "${{ steps.changed.outputs.files }}"
+
+          # Save errors for comment step
+          echo "errors<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$ERRORS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
           if [ "$FAILED" -eq 1 ]; then
             echo ""
             echo "::error::One or more hackathon YAML files failed validation"
             exit 1
           fi
+
+      - name: Comment validation errors on PR
+        if: failure() && steps.validate.outputs.errors != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const errors = `${{ steps.validate.outputs.errors }}`;
+            const body = `## ❌ Hackathon 校验失败 / Validation Failed\n\n\`\`\`\n${errors.trim()}\n\`\`\`\n\n请修复以上错误后重新提交。/ Please fix the errors above and push again.`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/apps/web/components/forms/CreateHackathonForm.tsx
+++ b/apps/web/components/forms/CreateHackathonForm.tsx
@@ -401,6 +401,8 @@ export function CreateHackathonForm({ lang }: CreateHackathonFormProps) {
         if (!reg || !reg.start || !reg.end) return false;
         for (const st of timelineStages) {
           if (st.start && !st.description) return false;
+          // start must be before end (CI Rule 5)
+          if (st.start && st.end && st.start > st.end) return false;
         }
         return true;
       }
@@ -822,7 +824,7 @@ export function CreateHackathonForm({ lang }: CreateHackathonFormProps) {
           ) : (
             <div className="flex flex-col items-end gap-3">
               <button type="button" onClick={handleSubmit}
-                disabled={!isLoggedIn || !isStepValid(0) || !isStepValid(1) || !isStepValid(2) || !isStepValid(4) || submitting}
+                disabled={!isLoggedIn || !isStepValid(0) || !isStepValid(1) || !isStepValid(2) || !isStepValid(3) || !isStepValid(4) || submitting}
                 aria-describedby={submitError ? 'hackathon-submit-error' : undefined}
                 className="px-6 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/80 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
                 {submitting ? t(lang, 'form.common.submitting') : t(lang, 'form.create_hackathon.submit_pr')} {'\u2192'}

--- a/apps/web/components/forms/form-utils.ts
+++ b/apps/web/components/forms/form-utils.ts
@@ -40,11 +40,12 @@ export function formatYaml(obj: Record<string, unknown>, indent = 0): string {
         if (typeof item === 'string') {
           lines.push(`${pad}  - "${item}"`);
         } else if (typeof item === 'object' && item !== null) {
-          const itemLines = formatYaml(item as Record<string, unknown>, indent + 2).split('\n');
+          const baseIndent = '  '.repeat(indent + 2);
+          const itemLines = formatYaml(item as Record<string, unknown>, indent + 2).split('\n').filter(l => l.length > 0);
           if (itemLines.length > 0) {
-            lines.push(`${pad}  - ${itemLines[0].trimStart()}`);
+            lines.push(`${pad}  - ${itemLines[0].slice(baseIndent.length)}`);
             for (const il of itemLines.slice(1)) {
-              lines.push(`${pad}    ${il.trimStart()}`);
+              lines.push(`${pad}    ${il.slice(baseIndent.length)}`);
             }
           }
         }


### PR DESCRIPTION
## Summary
- **formatYaml bug fix**: `trimStart()` → `slice(baseIndent.length)` — 修复数组对象嵌套缩进丢失问题（PR #71 的 rewards/judging/criteria 结构错乱根因）
- **CI 失败评论通知**: validate-hackathon workflow 校验失败时自动在 PR 评论具体错误信息
- **表单提交前校验**: 时间线增加 start < end 检查，提交按钮补上遗漏的 `isStepValid(3)`

## Test plan
- [x] `formatYaml` 输出经 js-yaml 解析验证，嵌套字段正确保留
- [x] `pnpm --filter @synnovator/web build` 构建通过
- [x] workflow YAML 语法校验通过
- [ ] 在页面上创建一个测试 hackathon，确认生成的 YAML 结构正确
- [ ] 故意触发校验失败，确认 PR 评论正常发送

🤖 Generated with [Claude Code](https://claude.com/claude-code)