### PR TITLE
fix(workflows): @mention author on validation failure

### DIFF
--- a/.github/workflows/validate-appeal.yml
+++ b/.github/workflows/validate-appeal.yml
@@ -76,7 +76,7 @@ jobs:
                       owner: context.repo.owner,
                       repo: context.repo.repo,
                       issue_number: issue.number,
-                      body: `❌ **Appeal window has closed.** Announcement period: ${h.timeline.announcement.start} — ${h.timeline.announcement.end}`,
+                      body: `❌ **Appeal window has closed.** @${author} Announcement period: ${h.timeline.announcement.start} — ${h.timeline.announcement.end}`,
                     });
                     return;
                   }
@@ -129,7 +129,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: `❌ **Appeal validation failed:**\n\n${errors.map(e => `- ${e}`).join('\n')}`,
+                body: `❌ **Appeal validation failed:**\n\n@${author} 请修复以下问题：\n\n${errors.map(e => `- ${e}`).join('\n')}`,
               });
             } else {
               // Add structured labels

--- a/.github/workflows/validate-bug.yml
+++ b/.github/workflows/validate-bug.yml
@@ -87,7 +87,7 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: issue.number,
                 body: [
-                  '⚠️ **Bug Report 信息不完整**\n',
+                  `⚠️ **Bug Report 信息不完整**\n\n@${issue.user.login} 请补充以下信息：\n`,
                   ...errors.map(e => `- ${e}`),
                   '',
                   '请编辑 Issue 补充以上信息。示例：',

--- a/.github/workflows/validate-feature.yml
+++ b/.github/workflows/validate-feature.yml
@@ -76,7 +76,7 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: issue.number,
                 body: [
-                  '⚠️ **Feature Request 信息不完整**\n',
+                  `⚠️ **Feature Request 信息不完整**\n\n@${issue.user.login} 请补充以下信息：\n`,
                   ...errors.map(e => `- ${e}`),
                   '',
                   '请编辑 Issue 补充以上信息。示例：',

--- a/.github/workflows/validate-nda.yml
+++ b/.github/workflows/validate-nda.yml
@@ -96,7 +96,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: `❌ **NDA validation failed:**\n\n${errors.map(e => `- ${e}`).join('\n')}\n\nPlease fix and re-edit this issue.`,
+                body: `❌ **NDA validation failed:**\n\n@${author} 请修复以下问题：\n\n${errors.map(e => `- ${e}`).join('\n')}\n\nPlease fix and re-edit this issue.`,
               });
             } else {
               await github.rest.issues.addLabels({

--- a/.github/workflows/validate-register.yml
+++ b/.github/workflows/validate-register.yml
@@ -168,7 +168,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: `❌ **Registration validation failed:**\n\n${errors.map(e => `- ${e}`).join('\n')}\n\nPlease fix and re-edit this issue.`,
+                body: `❌ **Registration validation failed:**\n\n@${author} 请修复以下问题：\n\n${errors.map(e => `- ${e}`).join('\n')}\n\nPlease fix and re-edit this issue.`,
               });
             } else {
               const labels = ['registered', `hackathon:${effectiveSlug}`];

--- a/.github/workflows/validate-score.yml
+++ b/.github/workflows/validate-score.yml
@@ -145,7 +145,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: `❌ **Score validation failed:**\n\n${errors.map(e => `- ${e}`).join('\n')}\n\nPlease fix and re-edit this issue.`,
+                body: `❌ **Score validation failed:**\n\n@${author} 请修复以下问题：\n\n${errors.map(e => `- ${e}`).join('\n')}\n\nPlease fix and re-edit this issue.`,
               });
             } else {
               await github.rest.issues.addLabels({

--- a/.github/workflows/validate-team.yml
+++ b/.github/workflows/validate-team.yml
@@ -139,7 +139,8 @@ jobs:
             }
 
             if (errors.length > 0) {
-              const body = `## ❌ Team Validation Failed\n\n${errors.map(e => `- ${e}`).join('\n')}`;
+              const author = context.payload.pull_request.user.login;
+              const body = `## ❌ Team Validation Failed\n\n@${author} Please fix the following issues:\n\n${errors.map(e => `- ${e}`).join('\n')}`;
               await github.rest.issues.createComment({
                 ...context.repo,
                 issue_number: context.payload.pull_request.number,


### PR DESCRIPTION
## Summary
- All 7 `validate-*.yml` workflows now @mention the PR/issue creator when validation fails
- Ensures authors receive GitHub notifications to fix issues promptly
- Applies to: team, appeal, score, nda, register, bug, feature validations

## Test plan
- [ ] Create a test PR touching `teams/` to trigger validate-team
- [ ] Verify the failure comment includes `@author`

🤖 Generated with [Claude Code](https://claude.com/claude-code)